### PR TITLE
Compressed inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,18 +89,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bed2gff"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "clap",
  "colored 1.9.4",
+ "flate2",
  "indoc",
  "log",
  "natord",
  "peak_alloc",
  "simple_logger",
  "thiserror",
+ "zip",
 ]
 
 [[package]]
@@ -93,10 +118,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cc"
@@ -104,6 +165,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -125,6 +187,16 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -183,16 +255,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "errno"
@@ -216,10 +342,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -251,6 +406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +430,15 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -301,6 +474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "natord"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,10 +513,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
+
+[[package]]
 name = "peak_alloc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d3978b0aa7d46c34452384c28264ac859c652b67635f6acfd598e1b6608de5"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "proc-macro2"
@@ -353,6 +564,12 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rustix"
@@ -388,6 +605,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "simple_logger"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +643,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -467,6 +712,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +728,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasm-bindgen"
@@ -685,3 +942,52 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bed2gff"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["alejandrogzi <jose.gonzalesdezavala1@unmsm.edu.pe>"]
 edition = "2021"
 license = "MIT"
@@ -21,6 +21,8 @@ simple_logger = "4.0.0"
 indoc = "1.0"
 natord = "1.0.9"
 chrono = "0.4.31"
+flate2 = "1.0"
+zip = "0.6"
 
 [lib]
 name = "bed2gff"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ chr7 bed2gff stop_codon 56805690 56805692 . + 0 ID=stop_codon:ENST00000581852.25
 
 in a few seconds.
 
+>**What's new on v.0.1.1**
+>
+> - bed2gtff now can accept `*.bed.gz` and `*.bed.zlib` as inputs (~2s cost)
+> - new dependencies have been added to support changes mentioned above
+> - `lib.rs` can handle inserted blank spaces at the end of compressed files (bug)
+> - the `date` watermark bug at the beginning of the files is now resolved!
+
+
 ## Usage
 ``` rust
 Usage: bed2gff[EXE] --bed <BED> --isoforms <ISOFORMS> --output <OUTPUT>
@@ -93,7 +101,7 @@ to install bed2gff on your system follow this steps:
 
 ## Library
 to include bed2gff as a library and use it within your project follow these steps:
-1. include `bed2gff = 0.1.0` under `[dependencies]` in the `Cargo.toml` file
+1. include `bed2gff = 0.1.1` under `[dependencies]` in the `Cargo.toml` file
 2. the library name is `bed2gff`, to use it just write:
 
     ``` rust
@@ -148,7 +156,7 @@ Following the rationale of [bed2gtf](https://github.com/alejandrogzi/bed2gtf), b
 
 ### To Do's
 
-- [ ] Allow users to input compressed files (e.g. .gz, .bgzip)
+- [x] Allow users to input compressed files (e.g. .gz, .zlib)
 - [x] Test GFF3 with different types of aligners
 - [ ] Improve the error module
 - [ ] Add test modules for most of the scripts

--- a/src/bed.rs
+++ b/src/bed.rs
@@ -4,7 +4,6 @@ use colored::Colorize;
 
 use crate::ParseError;
 
-
 #[derive(Clone, Debug, PartialEq)]
 pub struct BedRecord {
     chrom: String,
@@ -19,20 +18,23 @@ pub struct BedRecord {
     exon_end: Vec<i32>,
 }
 
-
-
 impl BedRecord {
     pub fn new(line: &str) -> Result<BedRecord, ParseError> {
-        
         if line.is_empty() {
-            eprintln!("{}", "bed2gff3 found an empty line! Check your input file.".bright_red());
+            eprintln!(
+                "{}",
+                "bed2gff3 found an empty line! Check your input file.".bright_red()
+            );
             return Err(ParseError::Empty);
         }
-        
+
         let fields = splitb(line, "\t")?;
-        
+
         if fields.len() < 12 {
-            eprintln!("{}", "bed2gff3 found an invalid BED line! Check your input file.".bright_red());
+            eprintln!(
+                "{}",
+                "bed2gff3 found an invalid BED line! Check your input file.".bright_red()
+            );
             return Err(ParseError::Invalid);
         }
 
@@ -44,8 +46,14 @@ impl BedRecord {
         let cds_start: i32 = fields[6].parse().unwrap();
         let cds_end: i32 = fields[7].parse().unwrap();
         let exon_count: i16 = fields[9].parse().unwrap();
-        let mut exon_start: Vec<i32> = splitb(fields[11].as_str(), ",")?.iter().map(|x| x.parse().unwrap()).collect();
-        let mut exon_end: Vec<i32> = splitb(fields[10].as_str(), ",")?.iter().map(|x| x.parse().unwrap()).collect();
+        let mut exon_start: Vec<i32> = splitb(fields[11].as_str(), ",")?
+            .iter()
+            .map(|x| x.parse().unwrap())
+            .collect();
+        let mut exon_end: Vec<i32> = splitb(fields[10].as_str(), ",")?
+            .iter()
+            .map(|x| x.parse().unwrap())
+            .collect();
 
         for x in 0..exon_count as usize {
             exon_start[x] += tx_start;
@@ -62,7 +70,7 @@ impl BedRecord {
             cds_end,
             exon_count,
             exon_start,
-            exon_end
+            exon_end,
         })
     }
 
@@ -107,16 +115,21 @@ impl BedRecord {
     }
 
     pub fn layer(line: &str) -> Result<(String, i32, String), ParseError> {
-        
         if line.is_empty() {
-            eprintln!("{}", "bed2gff3 found an empty line! Check your input file.".bright_red());
+            eprintln!(
+                "{}",
+                "bed2gff3 found an empty line! Check your input file.".bright_red()
+            );
             return Err(ParseError::Empty);
         }
-        
+
         let fields = splitb(line, "\t")?;
-        
+
         if fields.len() < 12 {
-            eprintln!("{}", "bed2gff3 found an invalid BED line! Check your input file.".bright_red());
+            eprintln!(
+                "{}",
+                "bed2gff3 found an invalid BED line! Check your input file.".bright_red()
+            );
             return Err(ParseError::Invalid);
         }
 
@@ -136,7 +149,7 @@ impl BedRecord {
             for exon in (start..end).step_by(1) {
                 let cds_exon_start = max(self.exon_start[exon as usize], self.cds_start);
                 let cds_exon_end = min(self.exon_end[exon as usize], self.cds_end);
-    
+
                 if cds_exon_start < cds_exon_end {
                     exon_frames[exon as usize] = cds % 3;
                     cds += cds_exon_end - cds_exon_start;
@@ -149,7 +162,7 @@ impl BedRecord {
             for exon in (start..end).step_by(1).rev() {
                 let cds_exon_start = max(self.exon_start[exon as usize], self.cds_start);
                 let cds_exon_end = min(self.exon_end[exon as usize], self.cds_end);
-                
+
                 if cds_exon_start < cds_exon_end {
                     exon_frames[exon as usize] = cds % 3;
                     cds += cds_exon_end - cds_exon_start;
@@ -162,8 +175,7 @@ impl BedRecord {
     }
 }
 
-
-pub fn splitb(line: &str, sep: &str)  -> Result<Vec<String>, ParseError> {
+pub fn splitb(line: &str, sep: &str) -> Result<Vec<String>, ParseError> {
     let bytes = line.as_bytes().iter().enumerate();
     let mut start = 0;
     let mut entries = Vec::new();
@@ -195,12 +207,29 @@ mod tests {
         let line = "chr11\t13934505\t13958243\tENST00000674667\t1000\t-\t13934505\t13958243\t0,0,200\t9\t224,217,228,198,149,142,115,157,49,\t0,1305,2811,5576,10085,14837,18016,19498,23689,";
         let list = splitb(line, "\t").unwrap();
         assert_eq!(list.len(), 12);
-        assert_eq!(list, ["chr11","13934505","13958243","ENST00000674667","1000","-","13934505","13958243","0,0,200","9","224,217,228,198,149,142,115,157,49,","0,1305,2811,5576,10085,14837,18016,19498,23689,"]);
+        assert_eq!(
+            list,
+            [
+                "chr11",
+                "13934505",
+                "13958243",
+                "ENST00000674667",
+                "1000",
+                "-",
+                "13934505",
+                "13958243",
+                "0,0,200",
+                "9",
+                "224,217,228,198,149,142,115,157,49,",
+                "0,1305,2811,5576,10085,14837,18016,19498,23689,"
+            ]
+        );
     }
 
     #[test]
     fn new_record() {
-        let line = "chr15\t81000922\t81005788\tENST00000267984\t0\t+\t81002271\t81003360\t0\t1\t4866,\t0,";
+        let line =
+            "chr15\t81000922\t81005788\tENST00000267984\t0\t+\t81002271\t81003360\t0\t1\t4866,\t0,";
         let record = BedRecord::new(line).unwrap();
 
         assert_eq!(record.chrom(), "chr15");
@@ -225,7 +254,8 @@ mod tests {
 
     #[test]
     fn invalid_record() {
-        let line = "chr15\t81000922\t81005788\tENST00000267984\t0\t+\t81002271\t81003360\t0\t1\t4866,";
+        let line =
+            "chr15\t81000922\t81005788\tENST00000267984\t0\t+\t81002271\t81003360\t0\t1\t4866,";
         let record = BedRecord::new(line);
 
         assert_eq!(record, Err(ParseError::Invalid));

--- a/src/codon.rs
+++ b/src/codon.rs
@@ -7,7 +7,6 @@ pub struct Codon {
     pub end2: i32,
 }
 
-
 impl Codon {
     pub fn new() -> Codon {
         Codon {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+#[warn(path_statements)]
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -14,4 +15,3 @@ impl From<std::io::Error> for ParseError {
         ParseError::Empty
     }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,44 +1,45 @@
 use bed2gff::bed2gff;
 
-use clap::{Arg, Command, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 
 use colored::Colorize;
 
-use std::string::String;
 use std::error::Error;
-
-
+use std::string::String;
 
 fn main() {
     let matches = Command::new("bed2gff")
-        .version("0.1.0")
+        .version("0.1.1")
         .author("Alejandro Gonzales-Irribarren <jose.gonzalesdezavala1@unmsm.edu.pe>")
         .about("A Rust BED-to-GFF translator")
-        .arg(Arg::new("bed")
-            .index(1)
-            .required(true)
-            .value_name("BED")
-            .help("BED file to convert"))
-        .arg(Arg::new("isoforms")
-            .index(2)
-            .required(true)
-            .value_name("ISOFORMS")
-            .help("Isoforms mapping file"))
-        .arg(Arg::new("output")
-            .index(3)
-            .required(true)
-            .value_name("OUTPUT")
-            .help("Output file name"))
+        .arg(
+            Arg::new("bed")
+                .index(1)
+                .required(true)
+                .value_name("BED")
+                .help("BED file to convert"),
+        )
+        .arg(
+            Arg::new("isoforms")
+                .index(2)
+                .required(true)
+                .value_name("ISOFORMS")
+                .help("Isoforms mapping file"),
+        )
+        .arg(
+            Arg::new("output")
+                .index(3)
+                .required(true)
+                .value_name("OUTPUT")
+                .help("Output file name"),
+        )
         .get_matches();
 
     if let Some(err) = run(matches).err() {
-        eprintln!("{} {}", 
-                "Error:".bright_red().bold(),
-                err);
+        eprintln!("{} {}", "Error:".bright_red().bold(), err);
         std::process::exit(1);
     }
 }
-
 
 fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
     let bed: &String = matches.get_one("bed").unwrap();
@@ -47,9 +48,11 @@ fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
 
     let _ = bed2gff(bed, isoforms, output);
 
-    println!("{} {}", 
-    "Success:".bright_green().bold(),
-    "BED file converted successfully!");
+    println!(
+        "{} {}",
+        "Success:".bright_green().bold(),
+        "BED file converted successfully!"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds new functionality to bed2gff. In short, .gz and .zlib files can be handled, even with inserted empty lines by the compression algorithms (bug). Two new functions have been added to handle this requirements. Also, a known bug on the date watermark has been resolved here.